### PR TITLE
fix: python3.11 support

### DIFF
--- a/han/autodecoder.py
+++ b/han/autodecoder.py
@@ -91,7 +91,6 @@ class AutoDecoder:
             )
             name, decoder = AutoDecoder.payload_decoder_functions[index]
             try:
-
                 decoded = (
                     dlde.decode_p1_readout(cast(dlde.DataReadout, message))
                     if name == "P1" and isinstance(message, dlde.DataReadout)


### PR DESCRIPTION
Due to changes in python 3.11 coroutines is now not allowed to be passed to `wait` directly

Check this for more info:
https://docs.python.org/3/library/asyncio-task.html#asyncio.wait

Check the issue https://github.com/toreamun/amshan-homeassistant/issues/62 for more info.
Credits goes to https://github.com/m0bygit for the fix!

Fixes https://github.com/toreamun/amshan-homeassistant/issues/62